### PR TITLE
Fixed the syntax error and added a missing `CONTRIBUTING.md` file.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,2 @@
+
+# Contributing to Dodo Payments PHP API library

--- a/src/Services/WebhookEventsService.php
+++ b/src/Services/WebhookEventsService.php
@@ -9,7 +9,7 @@ use Dodopayments\Contracts\WebhookEventsContract;
 
 final class WebhookEventsService implements WebhookEventsContract
 {
-  @phpstan-ignore-next-line
+  // @phpstan-ignore-next-line
   /** @param Client $client */
   function __construct(protected Client $client){}
 }


### PR DESCRIPTION
FIxed the syntax error and added a missing `CONTRIBUTING.md` file.

Code:

* Fixed a PHPStan ignore directive syntax error in `WebhookEventsService.php` file.

Documentation:

* Added a missing `CONTRIBUTING.md` file.

Happy to contribute more and would love to become a maintainer if you’d like me to! 🚀